### PR TITLE
Force IPv4 ping in ServerStart.bat when using DNS resolution

### DIFF
--- a/ServerStart.bat
+++ b/ServerStart.bat
@@ -609,7 +609,7 @@ IF NOT %MC_SERVER_IGNORE_OFFLINE% EQU 0 (
 )
 
 REM Ping minecraftforge before attempting download
-%MC_SYS32%\PING.EXE -n 2 -w 1000 minecraftforge.net | %MC_SYS32%\FIND.EXE "TTL="  1>> "%~dp0logs\serverstart.log" 2>&1
+%MC_SYS32%\PING.EXE -n 2 -w 1000 minecraftforge.net -4 | %MC_SYS32%\FIND.EXE "TTL="  1>> "%~dp0logs\serverstart.log" 2>&1
 IF %ERRORLEVEL% EQU 0 (
 	ECHO INFO: Ping of "minecraftforge.net" Successfull 1>>  "%~dp0logs\serverstart.log" 2>&1
 ) ELSE (


### PR DESCRIPTION
Ping does not respond with a TTL if the server responds with an IPv6
address. This essentially means that the script will think the user does
not have internet, if they have a public IPv6 address. Forcing IPv4 in
the ping command, ensures TTL gets returned, and the startup can
proceed.

This issue is only relevant in the batch script, as that is the only
script that asserts on TTL being present in the output. It is also only
an issue when pinging minecraftforge.net, as that relies on DNS
resolution. This means the output differs if the DNS server returns IPv4
(the A record) or IPv6 (the AAAA record).

Closes #88